### PR TITLE
Updated for 3.2.0.rc2 and Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gem 'spree', github: 'spree/spree'
+gem 'spree', github: 'spree/spree', branch: '3-2-stable'
 group :test do
   gem 'rails-controller-testing'
 end

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Configuration
     ```
     Somewhere in your asset path
 
-2. Override any of the partial templates. they are address, footer, totals, header, thanks , and the line_items. The whole tanks is wrapped in a thanks hook, so replace or add at will.
+2. Override any of the partial templates. they are address, footer, totals, header, thanks , and the line_items. The whole thanks is wrapped in a thanks hook, so replace or add at will.
 
 3. Set `Spree::HtmlInvoice::Config.set(:suppress_anonymous_address)` option to get blank addresses for anonymous email addresses (as created by my spree_last_address extension for empty/unknown user info)
 

--- a/spec/controllers/spree/admin/invoice_controller_spec.rb
+++ b/spec/controllers/spree/admin/invoice_controller_spec.rb
@@ -11,7 +11,7 @@ describe Spree::Admin::InvoiceController, type: :controller do
     end
 
     def send_request
-      get :lasku, { template: 'invoice', id: order.number }
+      get :lasku, params: { template: 'invoice', id: order.number }
     end
 
     it 'assigns @invoice to true' do

--- a/spree_html_invoice.gemspec
+++ b/spree_html_invoice.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_html_invoice'
-  s.version     = '3.2.0.alpha'
+  s.version     = '3.2.0.rc2'
   s.summary     = 'Print invoices from a spre order'
   s.required_ruby_version = '>= 1.9.3'
   s.authors = ["Torsten Ruger", "Chandramohan Rangaswamy"]
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true
 
-  s.add_dependency('spree_core', '~> 3.2.0.alpha')
+  s.add_dependency 'spree_core', '~> 3.2.0.rc2'
   s.add_development_dependency 'capybara', '~> 2.6'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl', '~> 4.5'


### PR DESCRIPTION
Fixed thanks typo in README
Fixed deprecation warning - use keyword syntax for get, put etc in controller tests